### PR TITLE
Fix android filepicker cancel.

### DIFF
--- a/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -47,6 +47,8 @@ namespace Plugin.FilePicker
 
             if (resultCode == Result.Canceled)
             {
+                // Notify user file picking was cancelled.
+                OnFilePickCancelled();
                 Finish();
             }
             else
@@ -69,6 +71,8 @@ namespace Plugin.FilePicker
                 }
                 catch (System.Exception readEx)
                 {
+                    // Notify user file picking failed.
+                    OnFilePickCancelled();
                     System.Diagnostics.Debug.Write(readEx);
                 }
                 finally
@@ -104,6 +108,12 @@ namespace Plugin.FilePicker
         }
 
         internal static event EventHandler<FilePickerEventArgs> FilePicked;
+        internal static event EventHandler<EventArgs> FilePickCancelled;
+
+        private static void OnFilePickCancelled()
+        {
+	        FilePickCancelled?.Invoke(null, null);
+        }
 
         private static void OnFilePicked(FilePickerEventArgs e)
         {

--- a/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
@@ -49,6 +49,7 @@ namespace Plugin.FilePicker
 				this.context.StartActivity(pickerIntent);
 
 				EventHandler<FilePickerEventArgs> handler = null;
+				EventHandler<EventArgs> cancelledHandler = null;
 
 				handler = (s, e) =>
 				{
@@ -63,6 +64,16 @@ namespace Plugin.FilePicker
 					});
 				};
 
+				cancelledHandler = (s, e) =>
+				{
+					var tcs = Interlocked.Exchange(ref this.completionSource, null);
+
+					FilePickerActivity.FilePickCancelled -= cancelledHandler;
+
+					tcs.SetResult(null);
+				};
+
+				FilePickerActivity.FilePickCancelled += cancelledHandler;
 				FilePickerActivity.FilePicked += handler;
 			}
 			catch (Exception exAct)


### PR DESCRIPTION
Allows users to cancel selecting a file (pressing the back button) while inside the file picker on Android.

Related issue: #4 