### PR TITLE
Updated error to make things a bit clearer

### DIFF
--- a/FilePicker/FilePicker/Plugin.FilePicker/CrossFilePicker.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker/CrossFilePicker.cs
@@ -37,7 +37,7 @@ namespace Plugin.FilePicker
 
         internal static Exception NotImplementedInReferenceAssembly()
         {
-            return new NotImplementedException("This functionality is not implemented in the portable version of this assembly.  You should reference the NuGet package from your main application project in order to reference the platform-specific implementation.");
+            return new NotImplementedException("This functionality is not implemented in the portable version of this assembly. You should reference the NuGet package from your main application project as well as all the implementing projects in order to reference the platform-specific implementation.");
         }
     }
 }


### PR DESCRIPTION
The error is raised when the package isn't referenced either by the PCL or by one of the implementing targets, this wasn't so clear from the error message.