### PR TITLE
iOS 11 fix for FilePicker

### DIFF
--- a/FilePicker/FilePicker/Plugin.FilePicker.Android/Plugin.FilePicker.Android.csproj
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Android/Plugin.FilePicker.Android.csproj
@@ -16,7 +16,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/FilePicker/FilePicker/Plugin.FilePicker.Android/Plugin.FilePicker.Android.csproj.bak
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Android/Plugin.FilePicker.Android.csproj.bak
@@ -16,6 +16,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,7 +48,9 @@
     <Compile Include="..\Plugin.FilePicker\CrossFilePicker.cs">
       <Link>CrossFilePicker.cs</Link>
     </Compile>
+    <Compile Include="FilePickerActivity.cs" />
     <Compile Include="FilePickerImplementation.cs" />
+    <Compile Include="IOUtil.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/FilePicker/FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
@@ -36,8 +36,17 @@ namespace Plugin.FilePicker
         {
             documentPicker.DidPickDocument += DocumentPicker_DidPickDocument;
             documentPicker.WasCancelled += DocumentPicker_WasCancelled;
-
+            documentPicker.DidPickDocumentAtUrls += DocumentPicker_DidPickDocumentAtUrls;
             UIApplication.SharedApplication.KeyWindow.RootViewController.PresentViewController (documentPicker, true, null);
+        }
+
+        private void DocumentPicker_DidPickDocumentAtUrls(object sender, UIDocumentPickedAtUrlsEventArgs e)
+        {
+            var control = (UIDocumentPickerViewController)sender;
+            foreach (var url in e.Urls)
+                DocumentPicker_DidPickDocument(control, new UIDocumentPickedEventArgs(url));
+
+            control.Dispose();
         }
 
         private void DocumentPicker_DidPickDocument (object sender, UIDocumentPickedEventArgs e)


### PR DESCRIPTION
Apple added a new call DidPickDocuments (with a "s" at the end) in iOS 11 and immediately deprecated DidPickDocument and doesn't call it anymore. Therefore you need to handle both to run on all iOS versions.